### PR TITLE
Fix canMatchPrice method bug.

### DIFF
--- a/src/main/java/seedu/address/model/property/PriceRange.java
+++ b/src/main/java/seedu/address/model/property/PriceRange.java
@@ -130,8 +130,9 @@ public class PriceRange {
         // [50, 100] , [99, 200] should match.
         // [100, 200] . [40, 99] should NOT match.
         // [50, 60], [10, 100] should match.
-        // [10, 100], [50, 60] should match.
-        return isWithinRange(buyRange.getLower(), sellRange) || isWithinRange(buyRange.getUpper(), sellRange);
+        // [10,100], [20, 40] should match, and vice versa.
+        return isWithinRange(buyRange.getLower(), sellRange) || isWithinRange(buyRange.getUpper(), sellRange)
+            || isWithinRange(sellRange.getLower(), buyRange) || isWithinRange(sellRange.getLower(), buyRange);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/property/HouseTest.java
+++ b/src/test/java/seedu/address/model/property/HouseTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 
 class HouseTest {
 
-    private House h1 = new House(HouseType.BUNGALOW, "Serangoon");
+    private House h1 = new House(HouseType.BUNGALOW, "Bishan");
     private House h2 = new House(HouseType.BUNGALOW, "Kovan");
     private House h3 = new House(HouseType.APARTMENT, "Serangoon");
-    private House h4 = new House(HouseType.BUNGALOW, "Serangoon");
+    private House h4 = new House(HouseType.BUNGALOW, "Bishan");
 
     @Test
     public void testHouseEquals() {

--- a/src/test/java/seedu/address/model/property/PriceRangeTest.java
+++ b/src/test/java/seedu/address/model/property/PriceRangeTest.java
@@ -87,6 +87,8 @@ class PriceRangeTest {
         PriceRange pr2 = new PriceRange(50, 150);
         PriceRange pr3 = new PriceRange(101, 150);
         PriceRange pr4 = new PriceRange(44, 46);
+        PriceRange pr5 = new PriceRange(20, 40);
+        PriceRange pr6 = new PriceRange(10, 100);
 
         assertTrue(PriceRange.canMatchPrice(pr1, pr2)); //values from 50-100 are valid matches
         assertTrue(PriceRange.canMatchPrice(pr2, pr1)); //other way should work also
@@ -99,6 +101,9 @@ class PriceRangeTest {
 
         assertFalse(PriceRange.canMatchPrice(pr1, pr3));
         assertFalse(PriceRange.canMatchPrice(pr3, pr1));
+
+        assertTrue(PriceRange.canMatchPrice(pr5, pr6));
+        assertTrue(PriceRange.canMatchPrice(pr6, pr5));
     }
 
     @Test


### PR DESCRIPTION
Previously, canMatchPrice can only check whether the first parameter
is within range of the second parameter. The vice versa check was
forgotten.

Now, I've added it so it should work.