### PR TITLE
Delete buyer command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddBuyerCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.buyer.Buyer;
 
 public class AddBuyerCommand extends Command {
 
-    public static final String COMMAND_WORD = "addbuyer";
+    public static final String COMMAND_WORD = "add-b";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add a new buyer. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSellerCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.seller.Seller;
  */
 public class AddSellerCommand extends Command {
 
-    public static final String COMMAND_WORD = "addseller";
+    public static final String COMMAND_WORD = "add-s";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a seller to the address book. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.buyer.Buyer;
+
+public class DeleteBuyerCommand extends Command {
+
+    public static final String COMMAND_WORD = "del-b";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the buyer identified by the index number used in the displayed buyer list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_CLIENT_SUCCESS = "Deleted buyer: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteBuyerCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Buyer> lastShownList = model.getFilteredBuyerList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+        }
+
+        Buyer buyerToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteBuyer(buyerToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteBuyerCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteBuyerCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteBuyerCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.buyer.Buyer;
 
 public class DeleteBuyerCommand extends Command {
 
-    public static final String COMMAND_WORD = "del-b";
+    public static final String COMMAND_WORD = "delete-b";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the buyer identified by the index number used in the displayed buyer list.\n"

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.AppointmentBuyerCommand;
 import seedu.address.logic.commands.AppointmentSellerCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteBuyerCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -66,6 +67,9 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+        
+        case DeleteBuyerCommand.COMMAND_WORD:
+            return new DeleteBuyerCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -67,7 +67,7 @@ public class AddressBookParser {
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
-        
+
         case DeleteBuyerCommand.COMMAND_WORD:
             return new DeleteBuyerCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
@@ -1,4 +1,25 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteBuyerCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
 public class DeleteBuyerCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteBuyerCommand
+     * and returns a DeleteBuyerCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteBuyerCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteBuyerCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteBuyerCommand.MESSAGE_USAGE), pe);
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class DeleteBuyerCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteBuyerCommandParser.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteBuyerCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-public class DeleteBuyerCommandParser {
+public class DeleteBuyerCommandParser implements Parser<DeleteBuyerCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteBuyerCommand

--- a/src/main/java/seedu/address/model/property/HouseType.java
+++ b/src/main/java/seedu/address/model/property/HouseType.java
@@ -115,6 +115,10 @@ public enum HouseType {
      */
     public static HouseType getHouseType(String house) {
         for (HouseType h : HouseType.values()) {
+            // Prevent accessing NULLHOUSETYPE enum
+            if (h == HouseType.NULLHOUSETYPE) {
+                continue;
+            }
             HouseType houseType = h.houseMappings.get(house.toLowerCase());
             if (houseType != null) {
                 return houseType;

--- a/src/main/java/seedu/address/storage/JsonAdaptedHouse.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedHouse.java
@@ -36,9 +36,6 @@ public class JsonAdaptedHouse {
      * @throws IllegalValueException if there were any data constraints violated in the adapted house.
      */
     public House toModelType() throws IllegalValueException {
-        if (houseType.equals("nullhouse")) {
-            return new House(HouseType.NULLHOUSETYPE, "nan");
-        }
         return new House(HouseType.getHouseType(houseType), location);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPropertyToSell.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPropertyToSell.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.property.Address;
 import seedu.address.model.property.House;
-import seedu.address.model.property.HouseType;
-import seedu.address.model.property.NullPropertyToSell;
 import seedu.address.model.property.PriceRange;
 import seedu.address.model.property.PropertyToSell;
 
@@ -36,17 +34,9 @@ class JsonAdaptedPropertyToSell {
      * Converts a given {@code PropertyToSell} into this class for Jackson use.
      */
     public JsonAdaptedPropertyToSell(PropertyToSell source) {
-        if (!(source instanceof NullPropertyToSell)) {
-            this.house = new JsonAdaptedHouse(source.getHouse());
-            this.priceRange = new JsonAdaptedPriceRange(source.getPriceRange());
-            this.address = source.getAddress().toString();
-        } else {
-            //Default value of NullPropertyToSell
-            System.out.println("NullPropertyToSell is translating to JSON format");
-            this.house = new JsonAdaptedHouse(new House(HouseType.NULLHOUSETYPE, "nan"));
-            this.priceRange = new JsonAdaptedPriceRange(new PriceRange(0, 0));
-            this.address = "nan";
-        }
+        this.house = new JsonAdaptedHouse(source.getHouse());
+        this.priceRange = new JsonAdaptedPriceRange(source.getPriceRange());
+        this.address = source.getAddress().toString();
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.buyer.Buyer;
+import seedu.address.model.buyer.BuyerNameContainsKeywordsPredicate;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.NameContainsKeywordsPredicate;
 import seedu.address.model.property.House;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -15,6 +15,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.buyer.Buyer;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.NameContainsKeywordsPredicate;
 import seedu.address.model.property.House;
@@ -113,6 +114,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredClientList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the client at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -125,6 +127,20 @@ public class CommandTestUtil {
         model.updateFilteredClientList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredClientList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the client at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showBuyerAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredBuyerList().size());
+
+        Buyer buyer = model.getFilteredBuyerList().get(targetIndex.getZeroBased());
+        final String[] splitName = buyer.getName().fullName.split("\\s+");
+        model.updateFilteredBuyerList(new BuyerNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredBuyerList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteBuyerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteBuyerCommandTest.java
@@ -4,24 +4,26 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalBuyers.getTypicalAddressBook;
+import static seedu.address.logic.commands.CommandTestUtil.showBuyerAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.BuyerAddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.SellerAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.buyer.Buyer;
+import seedu.address.testutil.TypicalBuyers;
+import seedu.address.testutil.TypicalClients;
 
 public class DeleteBuyerCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new SellerAddressBook(),
-            new BuyerAddressBook());
+    private Model model = new ModelManager(TypicalClients.getTypicalAddressBook(), new UserPrefs(),
+            new SellerAddressBook(), TypicalBuyers.getTypicalAddressBook());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
@@ -31,7 +33,7 @@ public class DeleteBuyerCommandTest {
         String expectedMessage = String.format(DeleteBuyerCommand.MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new SellerAddressBook(),
-                new BuyerAddressBook());
+                TypicalBuyers.getTypicalAddressBook());
         expectedModel.deleteBuyer(buyerToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
@@ -52,10 +54,10 @@ public class DeleteBuyerCommandTest {
         Buyer buyerToDelete = model.getFilteredBuyerList().get(INDEX_FIRST_CLIENT.getZeroBased());
         DeleteBuyerCommand deleteCommand = new DeleteBuyerCommand(INDEX_FIRST_CLIENT);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete);
+        String expectedMessage = String.format(DeleteBuyerCommand.MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new SellerAddressBook(),
-                new BuyerAddressBook());
+                TypicalBuyers.getTypicalAddressBook());
         expectedModel.deleteBuyer(buyerToDelete);
         showNobuyer(expectedModel);
 

--- a/src/test/java/seedu/address/logic/commands/DeleteBuyerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteBuyerCommandTest.java
@@ -1,0 +1,108 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalBuyers.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.BuyerAddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.SellerAddressBook;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.buyer.Buyer;
+
+public class DeleteBuyerCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new SellerAddressBook(),
+            new BuyerAddressBook());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Buyer buyerToDelete = model.getFilteredBuyerList().get(INDEX_FIRST_CLIENT.getZeroBased());
+        DeleteBuyerCommand deleteCommand = new DeleteBuyerCommand(INDEX_FIRST_CLIENT);
+
+        String expectedMessage = String.format(DeleteBuyerCommand.MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new SellerAddressBook(),
+                new BuyerAddressBook());
+        expectedModel.deleteBuyer(buyerToDelete);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredBuyerList().size() + 1);
+        DeleteBuyerCommand deleteCommand = new DeleteBuyerCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showBuyerAtIndex(model, INDEX_FIRST_CLIENT);
+
+        Buyer buyerToDelete = model.getFilteredBuyerList().get(INDEX_FIRST_CLIENT.getZeroBased());
+        DeleteBuyerCommand deleteCommand = new DeleteBuyerCommand(INDEX_FIRST_CLIENT);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_CLIENT_SUCCESS, buyerToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new SellerAddressBook(),
+                new BuyerAddressBook());
+        expectedModel.deleteBuyer(buyerToDelete);
+        showNobuyer(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showBuyerAtIndex(model, INDEX_FIRST_CLIENT);
+
+        Index outOfBoundIndex = INDEX_SECOND_CLIENT;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getBuyerAddressBook().getBuyerList().size());
+
+        DeleteBuyerCommand deleteCommand = new DeleteBuyerCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteBuyerCommand deleteFirstCommand = new DeleteBuyerCommand(INDEX_FIRST_CLIENT);
+        DeleteBuyerCommand deleteSecondCommand = new DeleteBuyerCommand(INDEX_SECOND_CLIENT);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteBuyerCommand deleteFirstCommandCopy = new DeleteBuyerCommand(INDEX_FIRST_CLIENT);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different buyer -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNobuyer(Model model) {
+        model.updateFilteredBuyerList(p -> false);
+
+        assertTrue(model.getFilteredBuyerList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 //import java.util.List;
 //import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddPropertyToBuyCommand;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-
 import seedu.address.logic.commands.AddBuyerCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddPropertyToBuyCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteBuyerCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditclientDescriptor;
@@ -58,6 +58,13 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_CLIENT), command);
+    }
+
+    @Test
+    public void parseCommand_deletebuyer() throws Exception {
+        DeleteBuyerCommand command = (DeleteBuyerCommand) parser.parseCommand(
+                DeleteBuyerCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased());
+        assertEquals(new DeleteBuyerCommand(INDEX_FIRST_CLIENT), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteBuyerCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.DeleteBuyerCommand;
 
 public class DeleteBuyerCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/DeleteBuyerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteBuyerCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.DeleteBuyerCommand;
+
+public class DeleteBuyerCommandParserTest {
+
+    private DeleteBuyerCommandParser parser = new DeleteBuyerCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteBuyerCommand() {
+        assertParseSuccess(parser, "1", new DeleteBuyerCommand(INDEX_FIRST_CLIENT));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeleteBuyerCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalBuyers.java
+++ b/src/test/java/seedu/address/testutil/TypicalBuyers.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.model.AddressBook;
+import seedu.address.model.BuyerAddressBook;
 import seedu.address.model.buyer.Buyer;
 
 /**
@@ -68,10 +68,10 @@ public class TypicalBuyers {
     /**
      * Returns an {@code AddressBook} with all the typical clients.
      */
-    public static AddressBook getTypicalAddressBook() {
-        AddressBook ab = new AddressBook();
+    public static BuyerAddressBook getTypicalAddressBook() {
+        BuyerAddressBook ab = new BuyerAddressBook();
         for (Buyer buyer : getTypicalBuyers()) {
-            ab.addclient(buyer);
+            ab.addBuyer(buyer);
         }
         return ab;
     }


### PR DESCRIPTION
## Why delete buyers
- Once the agent has closed a deal with a buyer, they might want to delete them to reduce the clutter
- He might have wrongly added the client as a buyer and maybe wanted it as a seller instead
## How to use
`delete-b INDEX` For example: `delete-b 1`
### Notes
- The index is based on the numbering when the buyer is listed (1. xxx)
- The index must be a positive number (E.g. 1,2,3,4...)