### PR TITLE
Branch update storage

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -94,34 +94,35 @@ public class MainApp extends Application {
         ReadOnlyAddressBook initialData;
         ReadOnlySellerAddressBook initialSellerData;
         ReadOnlyBuyerAddressBook initialBuyerData;
-
+        //Dummy AddressBook (will be delete later)
+        initialData = new AddressBook();
         try {
-            //addressBookOptional = storage.readAddressBook();
-            sellerAddressBookOptional = storage.readSellerAddressBook();
             buyerAddressBookOptional = storage.readBuyerAddressBook();
-            //if (!addressBookOptional.isPresent()) {
-            //    logger.info("Data file not found. Will be starting with a sample AddressBook");
-            //}
-            if (!sellerAddressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample SellerAddressBook");
-            }
             if (!buyerAddressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample BuyerAddressBook");
             }
-            initialData = new AddressBook();
-            initialSellerData = sellerAddressBookOptional.orElseGet(SampleDataUtil::getSampleSellerAddressBook);
+
             initialBuyerData = buyerAddressBookOptional.orElseGet(SampleDataUtil::getSampleBuyerAddressBook);
         } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-            initialSellerData = new SellerAddressBook();
+            logger.warning("Data file not in the correct format. Will be starting with an empty BuyerAddressBook");
             initialBuyerData = new BuyerAddressBook();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty AddressBook");
-            initialData = new AddressBook();
-            initialSellerData = new SellerAddressBook();
+            logger.warning("Problem while reading from the file. Will be starting with an empty BuyerAddressBook");
             initialBuyerData = new BuyerAddressBook();
+        }
 
+        try {
+            sellerAddressBookOptional = storage.readSellerAddressBook();
+            if (!sellerAddressBookOptional.isPresent()) {
+                logger.info("Data file not found. Will be starting with a sample SellerAddressBook");
+            }
+            initialSellerData = sellerAddressBookOptional.orElseGet(SampleDataUtil::getSampleSellerAddressBook);
+        } catch (DataConversionException e) {
+            logger.warning("Data file not in the correct format. Will be starting with an empty SellerAddressBook");
+            initialSellerData = new SellerAddressBook();
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the file. Will be starting with an empty SellerAddressBook");
+            initialSellerData = new SellerAddressBook();
         }
 
         return new ModelManager(initialData, userPrefs, initialSellerData, initialBuyerData);

--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -90,25 +90,25 @@ public class MainApp extends Application {
         Optional<ReadOnlyAddressBook> addressBookOptional;
         Optional<ReadOnlySellerAddressBook> sellerAddressBookOptional;
         Optional<ReadOnlyBuyerAddressBook> buyerAddressBookOptional;
-
+        // Create dummy value for initialData
         ReadOnlyAddressBook initialData;
         ReadOnlySellerAddressBook initialSellerData;
         ReadOnlyBuyerAddressBook initialBuyerData;
 
         try {
-            addressBookOptional = storage.readAddressBook();
+            //addressBookOptional = storage.readAddressBook();
             sellerAddressBookOptional = storage.readSellerAddressBook();
             buyerAddressBookOptional = storage.readBuyerAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Data file not found. Will be starting with a sample AddressBook");
-            }
+            //if (!addressBookOptional.isPresent()) {
+            //    logger.info("Data file not found. Will be starting with a sample AddressBook");
+            //}
             if (!sellerAddressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample SellerAddressBook");
             }
             if (!buyerAddressBookOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample BuyerAddressBook");
             }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+            initialData = new AddressBook();
             initialSellerData = sellerAddressBookOptional.orElseGet(SampleDataUtil::getSampleSellerAddressBook);
             initialBuyerData = buyerAddressBookOptional.orElseGet(SampleDataUtil::getSampleBuyerAddressBook);
         } catch (DataConversionException e) {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -50,7 +50,7 @@ public class LogicManager implements Logic {
         commandResult = command.execute(model);
 
         try {
-            storage.saveAddressBook(model.getAddressBook());
+            //storage.saveAddressBook(model.getAddressBook());
             storage.saveSellerAddressBook(model.getSellerAddressBook());
             storage.saveBuyerAddressBook(model.getBuyerAddressBook());
         } catch (IOException ioe) {

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,28 +7,23 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddBuyerCommand;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddPropertyToBuyCommand;
 import seedu.address.logic.commands.AddPropertyToSellCommand;
 import seedu.address.logic.commands.AddSellerCommand;
 import seedu.address.logic.commands.AppointmentBuyerCommand;
 import seedu.address.logic.commands.AppointmentSellerCommand;
 import seedu.address.logic.commands.ClearBuyerCommand;
-//import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearSellerCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteBuyerCommand;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteSellerCommand;
 import seedu.address.logic.commands.EditBuyerCommand;
 import seedu.address.logic.commands.EditSellerCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindBuyerCommand;
-//import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindSellerCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListBuyerCommand;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListSellerCommand;
 import seedu.address.logic.commands.MatchCommand;
 import seedu.address.logic.commands.SortCommand;
@@ -61,8 +56,8 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+        case AddBuyerCommand.COMMAND_WORD:
+            return new AddBuyerCommandParser().parse(arguments);
 
         case AddSellerCommand.COMMAND_WORD:
             return new AddSellerCommandParser().parse(arguments);
@@ -70,14 +65,8 @@ public class AddressBookParser {
         case EditBuyerCommand.COMMAND_WORD:
             return new EditBuyerCommandParser().parse(arguments);
 
-        //case EditCommand.COMMAND_WORD:
-        //    return new EditCommandParser().parse(arguments);
-
         case EditSellerCommand.COMMAND_WORD:
             return new EditSellerCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
 
         case DeleteBuyerCommand.COMMAND_WORD:
             return new DeleteBuyerCommandParser().parse(arguments);
@@ -102,8 +91,8 @@ public class AddressBookParser {
         case FindBuyerCommand.COMMAND_WORD:
             return new FindBuyerCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+        //case ListCommand.COMMAND_WORD:
+        //    return new ListCommand();
 
         case ListBuyerCommand.COMMAND_WORD:
             return new ListBuyerCommand();
@@ -125,9 +114,6 @@ public class AddressBookParser {
 
         case AppointmentSellerCommand.COMMAND_WORD:
             return new AppointmentSellerCommandParser().parse(arguments);
-
-        case AddBuyerCommand.COMMAND_WORD:
-            return new AddBuyerCommandParser().parse(arguments);
 
         case AddPropertyToBuyCommand.COMMAND_WORD:
             return new AddPropertyToBuyCommandParser().parse(arguments);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,12 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalClients.AMY;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -15,9 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.BuyerAddressBook;
@@ -26,13 +20,11 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.SellerAddressBook;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.client.Client;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonBuyerAddressBookStorage;
 import seedu.address.storage.JsonSellerAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
-import seedu.address.testutil.ClientBuilder;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy exception");
@@ -63,41 +55,35 @@ public class LogicManagerTest {
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
-    @Test
-    public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
-    }
+    //@Test
+    //public void execute_commandExecutionError_throwsCommandException() {
+    //    String deleteCommand = "delete 9";
+    //    assertCommandException(deleteCommand, MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+    //}
 
-    @Test
-    public void execute_validCommand_success() throws Exception {
-        String listCommand = ListCommand.COMMAND_WORD;
-        assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
-    }
-
-    @Test
-    public void execute_storageThrowsIoException_throwsCommandException() {
-        // Setup LogicManager with JsonAddressBookIoExceptionThrowingStub
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage =
-                new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
-        JsonSellerAddressBookStorage sellerAddressBookStorage = new JsonSellerAddressBookStorage(
-                temporaryFolder.resolve("selleraddressbook.json"));
-        JsonBuyerAddressBookStorage buyerAddressBookStorage = new JsonBuyerAddressBookStorage(
-                temporaryFolder.resolve("buyeraddressbook.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage,
-                sellerAddressBookStorage, buyerAddressBookStorage);
-        logic = new LogicManager(model, storage);
-
-        // Execute add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY;
-        Client expectedClient = new ClientBuilder(AMY).withTags().build();
-        ModelManager expectedModel = new ModelManager();
-        expectedModel.addClient(expectedClient);
-        String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
-        assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
-    }
+    //@Test
+    //public void execute_storageThrowsIoException_throwsCommandException() {
+    //    // Setup LogicManager with JsonAddressBookIoExceptionThrowingStub
+    //    JsonAddressBookStorage addressBookStorage =
+    //            new JsonAddressBookIoExceptionThrowingStub(temporaryFolder.resolve("ioExceptionAddressBook.json"));
+    //    JsonUserPrefsStorage userPrefsStorage =
+    //            new JsonUserPrefsStorage(temporaryFolder.resolve("ioExceptionUserPrefs.json"));
+    //    JsonSellerAddressBookStorage sellerAddressBookStorage = new JsonSellerAddressBookStorage(
+    //            temporaryFolder.resolve("selleraddressbook.json"));
+    //    JsonBuyerAddressBookStorage buyerAddressBookStorage = new JsonBuyerAddressBookStorage(
+    //            temporaryFolder.resolve("buyeraddressbook.json"));
+    //    StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage,
+    //            sellerAddressBookStorage, buyerAddressBookStorage);
+    //    logic = new LogicManager(model, storage);
+    //
+    //    // Execute add command
+    //    String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY;
+    //    Client expectedClient = new ClientBuilder(AMY).withTags().build();
+    //    ModelManager expectedModel = new ModelManager();
+    //    expectedModel.addClient(expectedClient);
+    //    String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
+    //    assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
+    //}
 
     @Test
     public void getFilteredclientList_modifyList_throwsUnsupportedOperationException() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,44 +9,28 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBuyers.CHAD;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 
-//import java.util.Arrays;
-//import java.util.List;
-//import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddBuyerCommand;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddPropertyToBuyCommand;
-//import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteBuyerCommand;
-import seedu.address.logic.commands.DeleteCommand;
-//import seedu.address.logic.commands.EditCommand;
-//import seedu.address.logic.commands.EditCommand.EditclientDescriptor;
 import seedu.address.logic.commands.ExitCommand;
-//import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.buyer.Buyer;
-import seedu.address.model.client.Client;
-//import seedu.address.model.client.NameContainsKeywordsPredicate;
-//import seedu.address.model.property.NullPropertyToBuy;
 import seedu.address.testutil.BuyerBuilder;
-import seedu.address.testutil.ClientBuilder;
 import seedu.address.testutil.ClientUtil;
-//import seedu.address.testutil.EditClientDescriptorBuilder;
-
 
 public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
 
-    @Test
-    public void parseCommand_add() throws Exception {
-        Client client = new ClientBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(ClientUtil.getAddCommand(client));
-        assertEquals(new AddCommand(client), command);
-    }
+    //@Test
+    //public void parseCommand_add() throws Exception {
+    //    Client client = new ClientBuilder().build();
+    //    AddCommand command = (AddCommand) parser.parseCommand(ClientUtil.getAddCommand(client));
+    //    assertEquals(new AddCommand(client), command);
+    //}
 
     //@Test
     //public void parseCommand_clear() throws Exception {
@@ -54,15 +38,15 @@ public class AddressBookParserTest {
     //    assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     //}
 
-    @Test
-    public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_CLIENT), command);
-    }
+    //@Test
+    //public void parseCommand_delete() throws Exception {
+    //    DeleteCommand command = (DeleteCommand) parser.parseCommand(
+    //            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased());
+    //    assertEquals(new DeleteCommand(INDEX_FIRST_CLIENT), command);
+    //}
 
     @Test
-    public void parseCommand_deletebuyer() throws Exception {
+    public void parseCommand_deleteBuyer() throws Exception {
         DeleteBuyerCommand command = (DeleteBuyerCommand) parser.parseCommand(
                 DeleteBuyerCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased());
         assertEquals(new DeleteBuyerCommand(INDEX_FIRST_CLIENT), command);
@@ -97,11 +81,11 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
-    @Test
-    public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
-    }
+    //@Test
+    //public void parseCommand_list() throws Exception {
+    //    assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+    //    assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    //}
 
     @Test
     public void parseCommand_addbuyer() throws Exception {


### PR DESCRIPTION
Ignore the original Address Book
# Now the seller book and address book can be initialize separately
- If seller book file is not found, only the example seller book will be initialized, vice-versa as buyer's

# Todo later
- Need to remove all the parameters and classes about original AddressBook 